### PR TITLE
feat: response body to extra_output if json

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,10 @@ class httpExecutor extends Execution {
 
     http(values)
       .then(body => {
+        if (values.json) {
+          endOptions.extra_output = body;
+        }
+
         if (values.responseToFile) {
           let writeStream = fs.createWriteStream(values.responseToFile);
           writeStream.write(body, 'binary');


### PR DESCRIPTION
De la [documentación oficial](https://www.npmjs.com/package/request-promise)

```javascript
// GET something from a JSON REST API
var options = {
    uri: 'https://api.github.com/user/repos',
    qs: {
        access_token: 'xxxxx xxxxx' // -> uri + '?access_token=xxxxx%20xxxxx'
    },
    headers: {
        'User-Agent': 'Request-Promise'
    },
    json: true // Automatically parses the JSON string in the response
};
```

Como ya lo parsea a objeto, creo que no hay que hacer nada más